### PR TITLE
Add field for ordering the snapshot by the whitelist

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/AbstractReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/AbstractReader.java
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.debezium.relational.TableId;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
@@ -47,6 +48,7 @@ public abstract class AbstractReader implements Reader {
     private final int maxBatchSize;
     private final Metronome metronome;
     private final AtomicReference<Runnable> uponCompletion = new AtomicReference<>();
+    protected List<TableId> snapshottedTables = new ArrayList<TableId>();;
 
     /**
      * Create a snapshot reader.
@@ -284,5 +286,9 @@ public abstract class AbstractReader implements Reader {
             }
             this.records.put(record);
         }
+    }
+
+    public List<TableId> getSnapshottedTables() {
+        return snapshottedTables;
     }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -377,6 +377,7 @@ public class MySqlConnectorConfig {
     private static final String DATABASE_WHITELIST_NAME = "database.whitelist";
     private static final String TABLE_WHITELIST_NAME = "table.whitelist";
     private static final String TABLE_IGNORE_BUILTIN_NAME = "table.ignore.builtin";
+    private static final String SNAPSHOT_ORDERED_BY_WHITELIST_NAME = "snapshot.order.whitelist";
 
     /**
      * Default size of the binlog buffer used for examining transactions and
@@ -783,6 +784,16 @@ public class MySqlConnectorConfig {
                     "The value of those properties is the select statement to use when retrieving data from the specific table during snapshotting. " +
                     "A possible use case for large append-only tables is setting a specific point where to start (resume) snapshotting, in case a previous snapshotting was interrupted.");
 
+    public static final Field SNAPSHOT_ORDERED_BY_WHITELIST = Field.create(SNAPSHOT_ORDERED_BY_WHITELIST_NAME)
+            .withDisplayName("Table import order determined by whitelist")
+            .withType(Type.BOOLEAN)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDescription("When tables are imported in the snapshot, use the order specified in the whitelist to "
+                             + "determine the order in which they are imported.")
+            .withValidation(Field::isBoolean)
+            .withDefault(false);
+
     /**
      * Method that generates a Field for specifying that string columns whose names match a set of regular expressions should
      * have their values truncated to be no longer than the specified number of characters.
@@ -831,7 +842,8 @@ public class MySqlConnectorConfig {
                                                      SSL_MODE, SSL_KEYSTORE, SSL_KEYSTORE_PASSWORD,
                                                      SSL_TRUSTSTORE, SSL_TRUSTSTORE_PASSWORD, JDBC_DRIVER,
                                                      BIGINT_UNSIGNED_HANDLING_MODE,
-                                                     EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE);
+                                                     EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE,
+                                                     SNAPSHOT_ORDERED_BY_WHITELIST);
 
     /**
      * The set of {@link Field}s that are included in the {@link #configDef() configuration definition}. This includes
@@ -862,7 +874,7 @@ public class MySqlConnectorConfig {
                     EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE);
         Field.group(config, "Connector", CONNECTION_TIMEOUT_MS, KEEP_ALIVE, MAX_QUEUE_SIZE, MAX_BATCH_SIZE, POLL_INTERVAL_MS,
                     SNAPSHOT_MODE, SNAPSHOT_MINIMAL_LOCKING, TIME_PRECISION_MODE, DECIMAL_HANDLING_MODE,
-                    BIGINT_UNSIGNED_HANDLING_MODE);
+                    BIGINT_UNSIGNED_HANDLING_MODE, SNAPSHOT_ORDERED_BY_WHITELIST);
         return config;
     }
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -123,6 +123,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         assertNoConfigurationErrors(result, MySqlConnectorConfig.SSL_TRUSTSTORE_PASSWORD);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.DECIMAL_HANDLING_MODE);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.TIME_PRECISION_MODE);
+        assertNoConfigurationErrors(result, MySqlConnectorConfig.SNAPSHOT_ORDERED_BY_WHITELIST);
         assertConfigurationErrors(result, KafkaDatabaseHistory.BOOTSTRAP_SERVERS);
         assertConfigurationErrors(result, KafkaDatabaseHistory.TOPIC);
         assertNoConfigurationErrors(result, KafkaDatabaseHistory.RECOVERY_POLL_ATTEMPTS);
@@ -176,6 +177,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         assertNoConfigurationErrors(result, MySqlConnectorConfig.SSL_TRUSTSTORE_PASSWORD);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.DECIMAL_HANDLING_MODE);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.TIME_PRECISION_MODE);
+        assertNoConfigurationErrors(result, MySqlConnectorConfig.SNAPSHOT_ORDERED_BY_WHITELIST);
         assertNoConfigurationErrors(result, KafkaDatabaseHistory.BOOTSTRAP_SERVERS);
         assertNoConfigurationErrors(result, KafkaDatabaseHistory.TOPIC);
         assertNoConfigurationErrors(result, KafkaDatabaseHistory.RECOVERY_POLL_ATTEMPTS);
@@ -223,6 +225,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         assertNoConfigurationErrors(result, MySqlConnectorConfig.SSL_TRUSTSTORE_PASSWORD);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.DECIMAL_HANDLING_MODE);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.TIME_PRECISION_MODE);
+        assertNoConfigurationErrors(result, MySqlConnectorConfig.SNAPSHOT_ORDERED_BY_WHITELIST);
         assertNoConfigurationErrors(result, KafkaDatabaseHistory.BOOTSTRAP_SERVERS);
         assertNoConfigurationErrors(result, KafkaDatabaseHistory.TOPIC);
         assertNoConfigurationErrors(result, KafkaDatabaseHistory.RECOVERY_POLL_ATTEMPTS);

--- a/debezium-core/src/main/java/io/debezium/relational/TableId.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableId.java
@@ -7,6 +7,8 @@ package io.debezium.relational;
 
 import io.debezium.annotation.Immutable;
 
+import java.util.List;
+
 /**
  * Unique identifier for a database table.
  *
@@ -119,6 +121,26 @@ public final class TableId implements Comparable<TableId> {
     public int compareToIgnoreCase(TableId that) {
         if (this == that) return 0;
         return this.id.compareToIgnoreCase(that.id);
+    }
+
+    public int compareToWithWhitelist(TableId that, List<String> whitelist) {
+        if (this == that) return 0;
+        if (whitelist.isEmpty()) {
+            return compareToIgnoreCase(that);
+        }
+
+        int strposThis = whitelist.indexOf(this.id.toLowerCase());
+        int strposThat = whitelist.indexOf(that.id.toLowerCase());
+
+        if (strposThis == -1 && strposThat == -1) {
+            return compareToIgnoreCase(that);
+        } else if (strposThis == -1) {
+            return 1;
+        } else if (strposThat == -1) {
+            return -1;
+        }
+
+        return Integer.compare(strposThis, strposThat);
     }
 
     @Override

--- a/debezium-core/src/test/java/io/debezium/relational/TableIdComparisonTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/TableIdComparisonTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class TableIdComparisonTest {
+
+    @Test
+    public void testTableIdSelfCompare() {
+        TableId left = new TableId("catalog1", "schema1", "table1");
+
+        assertThat(left.compareTo(left)).isEqualTo(0);
+    }
+
+    @Test
+    public void testTableIdCompare() {
+        TableId left = new TableId("catalog1", "schema1", "table1");
+        TableId right = new TableId("catalog1", "schema1", "table1");
+
+        assertThat(left.compareTo(right)).isEqualTo(0);
+    }
+
+    @Test
+    public void testTableIdCompareCaseSensitive() {
+        TableId left = new TableId("catalog1", "schema1", "table1");
+        TableId right = new TableId("CATALOG1", "schema1", "table1");
+
+        assertThat(left.compareTo(right)).isGreaterThan(0);
+        assertThat(right.compareTo(left)).isLessThan(0);
+    }
+
+    @Test
+    public void testTableIdCompareIgnoreCase() {
+        TableId left = new TableId("catalog1", "schema1", "table1");
+        TableId right = new TableId("CATALOG1", "schema1", "table1");
+
+        assertThat(left.compareToIgnoreCase(right)).isEqualTo(0);
+    }
+
+    @Test
+    public void testTableIdCompareUnequal() {
+        TableId left = new TableId("catalog1", "schema1", "table1");
+        TableId right = new TableId("catalog1", "schema1", "table2");
+
+        assertThat(left.compareTo(right)).isLessThan(0);
+        assertThat(right.compareTo(left)).isGreaterThan(0);
+    }
+
+    @Test
+    public void testTableIdCompareWithEmptyWhitelist() {
+        List<String> whitelist = new ArrayList<>();
+        TableId left = new TableId(null, "schema1", "table1");
+        TableId right = new TableId(null, "schema1", "table2");
+
+        assertThat(left.compareToWithWhitelist(right, whitelist)).isLessThan(0);
+        assertThat(right.compareToWithWhitelist(left, whitelist)).isGreaterThan(0);
+    }
+
+    private List<String> getTestWhitelist() {
+        List<String> whitelist = new ArrayList<>();
+        whitelist.add("schema2.table1");
+        whitelist.add("schema2.table2");
+        whitelist.add("schema1.table1");
+        whitelist.add("schema2.table3");
+        whitelist.add("schema1.table2");
+
+        return whitelist;
+    }
+
+    @Test
+    public void testTableIdSelfCompareWithWhitelist() {
+        TableId left = new TableId(null, "schema1", "table1");
+
+        assertThat(left.compareToWithWhitelist(left, getTestWhitelist())).isEqualTo(0);
+    }
+
+    @Test
+    public void testTableIdCompareWithWhitelistWithLeftNotPresent() {
+        List<String> whitelist = new ArrayList<String>();
+        TableId left = new TableId(null, "schema1", "table5");
+        TableId right = new TableId(null, "schema1", "table2");
+
+        assertThat(left.compareToWithWhitelist(right, getTestWhitelist())).isEqualTo(1);
+    }
+
+    @Test
+    public void testTableIdCompareWithWhitelistWithRightNotPresent() {
+        TableId left = new TableId(null, "schema1", "table1");
+        TableId right = new TableId(null, "schema1", "table6");
+
+        assertThat(left.compareToWithWhitelist(right, getTestWhitelist())).isEqualTo(-1);
+    }
+
+    @Test
+    public void testTableIdCompareWithWhitelistWithNeitherPresent() {
+        TableId left = new TableId(null, "schema1", "table5");
+        TableId right = new TableId(null, "schema1", "table6");
+
+        assertThat(left.compareToWithWhitelist(right, getTestWhitelist())).isEqualTo(left.compareToIgnoreCase(right));
+    }
+
+    @Test
+    public void testTableIdCompareWithWhitelistWithSameTable() {
+        TableId left = new TableId(null, "schema1", "table1");
+        TableId right = new TableId(null, "schema1", "table1");
+
+        assertThat(left.compareToWithWhitelist(right, getTestWhitelist())).isEqualTo(0);
+    }
+
+    @Test
+    public void testTableIdCompareWithWhitelistWithLeftFirst() {
+        TableId left = new TableId(null, "schema1", "table1");
+        TableId right = new TableId(null, "schema1", "table2");
+
+        assertThat(left.compareToWithWhitelist(right, getTestWhitelist())).isEqualTo(-1);
+    }
+
+    @Test
+    public void testTableIdCompareWithWhitelistWithRightFirst() {
+        TableId left = new TableId(null, "schema1", "table2");
+        TableId right = new TableId(null, "schema1", "table1");
+
+        assertThat(left.compareToWithWhitelist(right, getTestWhitelist())).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
Context

This is a proposal for a way to sort the tables being snapshotted by debezium from mysql in the order set in a whitelist. The requirements came out of an ETL process where the contents of one table required another to have been processed first; in order to do that, we need to tell debezium to snapshot the tables in a specific order

Implementation

A new custom iterator is subbed in (if the proper config var is set), that will return the table ids in the appropriate order. A custom comparison function is added to the table Id class in core, which can be reused at a later stage for the postgres and mongodb connectors if required